### PR TITLE
Add PWA support and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The **BASEURL** should say `/repositoryname`
 
 If there are problems with loading assets like CSS files and images, make sure that both **URL** and **BASEURL** are set correctly.
 
+### Progressive Web App
+
+This project ships with a basic service worker and web app manifest so it can be installed as a Progressive Web App. The site is automatically built and deployed to GitHub Pages via a GitHub Actions workflow.
+
 ----
 
 **Not for HTTPS served repos.**

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,8 @@
 
   <link rel="shortcut icon" href="{{ site.basurl }}/favicon.ico?" type="image/x-icon">
 <link rel="icon" href="{{ site.baseurl }}/favicon.ico?" type="image/x-icon">
+  <link rel="manifest" href="{{ site.baseurl }}/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
     <meta name="description" content="{{ site.description }}">
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,9 +17,17 @@
 
     <!-- {% include newsletter.html %} -->
 
-    {% include footer.html %}
+   {% include footer.html %}
 
-   {% include Scroll_to_Top.html %}  
+   {% include Scroll_to_Top.html %}
+
+   <script>
+   if ('serviceWorker' in navigator) {
+     window.addEventListener('load', function() {
+       navigator.serviceWorker.register('{{ site.baseurl }}/service-worker.js');
+     });
+   }
+   </script>
 
 </body>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,6 +14,14 @@
 
     {{ content }}
 
+    <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('{{ site.baseurl }}/service-worker.js');
+      });
+    }
+    </script>
+
     </body>
 
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,23 @@
+---
+layout: null
+---
+{
+  "name": "TAKOPHOTOS",
+  "short_name": "Takophotos",
+  "start_url": "{{ site.baseurl }}/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "{{ site.baseurl }}/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "{{ site.baseurl }}/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,21 @@
+---
+layout: null
+---
+const CACHE_NAME = 'takophotos-cache-v1';
+const OFFLINE_URLS = [
+  '{{ site.baseurl }}/',
+  '{{ site.baseurl }}/index.html',
+  '{{ site.baseurl }}/manifest.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest and service worker for basic PWA functionality
- register service worker in layouts and expose manifest link
- configure GitHub Actions workflow to build and deploy site to GitHub Pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f835486a883279ad30b8b595ed70f